### PR TITLE
Feedback on calworkshop

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -162,7 +162,7 @@ you've wired up this TwiML to your number, get a neighbor to test it out.
     <Response>
       <Say>Please wait while we forward your call</Say>
       <Dial>YOUR PHONE NUMBER</Dial>
-    </Resposne>
+    </Response>
 
 
 Voice Mailbox
@@ -178,7 +178,7 @@ into your bin and save. You can now leave messages on your number.
     <Response>
       <Say>After the beep, record your message</Say>
       <Record/>
-    </Resposne>
+    </Response>
 
 After you're done recording your message, hang up. Twilio begins processing the
 recording right after your done. Head to your `recording log
@@ -202,7 +202,7 @@ start up a conversation.
       <Dial>
         <Conference>vip</Conference>
       </Dial>
-    </Resposne>
+    </Response>
 
 
 Swiss-Army Phone Number

--- a/make_call.py
+++ b/make_call.py
@@ -5,7 +5,8 @@ TWILIO_AUTH_TOKEN = ''
 
 TO_NUMBER = ''       # Your verified phone number
 FROM_NUMBER = ''     # Your Twilio phone number
-TWIML_URL = 'http://twimlets.com/message?Message[1]=Hello+World'
+TWIML_URL = 'http://twimlets.com/message?Message=Hello+World'
 
 client = TwilioRestClient(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN)
-client.calls.messages.create(to=TO_NUMBER, from_=FROM_NUMBER, url=TWIML_URL)
+client.calls.create(to=TO_NUMBER, from_=FROM_NUMBER, url=TWIML_URL)
+


### PR DESCRIPTION
- Incorrect function call: `client.calls.messages.create` fixed to `client.calls.create`.
- Typos on `quickstart.rst`
- **A more troubling issue**: The Twimlets URLs in the quickstart (http://twimlets.com/message?Message[1]=Hello+World') **cause application errors** when specified both in the Python client, as well as in the Numbers Web UI. Removing the '[1]' causes it to work, but the Twimlets documentation does not reflect this. 

We may need to use something besides Twimlets - apart from that brokenness, they aren't really introduced in the Quickstart (what is a Twimlet? it makes twiml for me? wait, is a twimlet twiml?)...
